### PR TITLE
minor fixes: fmt and pointer receivers

### DIFF
--- a/adsb.go
+++ b/adsb.go
@@ -79,9 +79,9 @@ func (m Msg) HasPosition() bool     { return m.hasPosition }
 func (m Msg) HasVerticalRate() bool { return m.hasVerticalRate }
 
 // We create some ADSB messages outside of this lib, and need to assert these values
-func (m Msg) SetHasGroundSpeed() { m.hasGroundSpeed = true }
-func (m Msg) SetHasTrack()       { m.hasTrack = true }
-func (m Msg) SetHasPosition()    { m.hasPosition = true }
+func (m *Msg) SetHasGroundSpeed() { m.hasGroundSpeed = true }
+func (m *Msg) SetHasTrack()       { m.hasTrack = true }
+func (m *Msg) SetHasPosition()    { m.hasPosition = true }
 
 func (m Msg) String() string {
 	s := fmt.Sprintf("%s%d : %s", m.Type, m.SubType, m.Icao24)

--- a/adsb.go
+++ b/adsb.go
@@ -70,7 +70,7 @@ func (m Msg) IsMLAT() bool { return m.Type == "MLAT" }
 
 func (m Msg) IsMasked() bool { return strings.HasPrefix(string(m.Icao24), "~") }
 
-//func (m Msg)HasAltitude()     bool { return m.hasAltitude }
+func (m Msg) HasAltitude() bool     { return m.hasAltitude }
 func (m Msg) HasCallsign() bool     { return m.hasCallsign }
 func (m Msg) HasSquawk() bool       { return m.hasSquawk }
 func (m Msg) HasGroundSpeed() bool  { return m.hasGroundSpeed }
@@ -79,9 +79,13 @@ func (m Msg) HasPosition() bool     { return m.hasPosition }
 func (m Msg) HasVerticalRate() bool { return m.hasVerticalRate }
 
 // We create some ADSB messages outside of this lib, and need to assert these values
-func (m *Msg) SetHasGroundSpeed() { m.hasGroundSpeed = true }
-func (m *Msg) SetHasTrack()       { m.hasTrack = true }
-func (m *Msg) SetHasPosition()    { m.hasPosition = true }
+func (m *Msg) SetHasAltitude()     { m.hasAltitude = true }
+func (m *Msg) SetHasCallsign()     { m.hasCallsign = true }
+func (m *Msg) SetHasSquawk()       { m.hasSquawk = true }
+func (m *Msg) SetHasGroundSpeed()  { m.hasGroundSpeed = true }
+func (m *Msg) SetHasTrack()        { m.hasTrack = true }
+func (m *Msg) SetHasPosition()     { m.hasPosition = true }
+func (m *Msg) SetHasVerticalRate() { m.hasVerticalRate = true }
 
 func (m Msg) String() string {
 	s := fmt.Sprintf("%s%d : %s", m.Type, m.SubType, m.Icao24)

--- a/adsb.go
+++ b/adsb.go
@@ -17,9 +17,9 @@ type IcaoId string
 //
 type Msg struct {
 	// This set of data is basically the SBS1 format, not the ADS-B format.
-	
-	Type string //`json:"-"` // = 0 // type	 (MSG, STA, ID, AIR, SEL or CLK). We ignore all but MSG.
-	SubType int64 `json:"-"` // = 1 // Type	 MSG sub types 1 to 8. Not used by other message types.
+
+	Type    string //`json:"-"` // = 0 // type	 (MSG, STA, ID, AIR, SEL or CLK). We ignore all but MSG.
+	SubType int64  `json:"-"` // = 1 // Type	 MSG sub types 1 to 8. Not used by other message types.
 	// Session = 2 // ID	 Database Session record number
 	// AircraftID = 3 //	 Database Aircraft record number
 	Icao24 IcaoId //  = 4 //	 Aircraft Mode S hexadecimal code
@@ -35,26 +35,26 @@ type Msg struct {
 	//TimeGen = 7 // message generated	  As it says
 	//DateLog = 8 // message logged	  As it says
 	//TimeLog = 9 // message logged	  As it says
-	Callsign string // = 10 //	 An eight digit flight ID - can be flight number or registration
-	Altitude int64 // = 11 //	 Mode C altitude. Height relative to 1013.2mb (Flight Level).
-	GroundSpeed int64 // = 12 //	 Speed over ground (not indicated airspeed)
-	Track int64 // = 13 //	 Track of aircraft (not heading). Derived from the velocity E/W, N/S
+	Callsign    string // = 10 //	 An eight digit flight ID - can be flight number or registration
+	Altitude    int64  // = 11 //	 Mode C altitude. Height relative to 1013.2mb (Flight Level).
+	GroundSpeed int64  // = 12 //	 Speed over ground (not indicated airspeed)
+	Track       int64  // = 13 //	 Track of aircraft (not heading). Derived from the velocity E/W, N/S
 
 	Position geo.Latlong
 	//Latitude float64 // = 14 //	 North and East positive. South and West negative.
 	//Longitude float64 // = 15 //	 North and East positive. South and West negative.
 
-	VerticalRate int64 // = 16 //	 64ft resolution
-	Squawk string // = 17 //	 Assigned Mode A squawk code.
-	AlertSquawkChange bool `json:"-"`// = 18 // (Squawk change)	 Flag to indicate squawk has changed.
-	Emergency bool `json:"-"`// = 19 //	 Flag to indicate emergency code has been set
-	SPI bool `json:"-"`// = 20 // (Ident)	 Flag to indicate transponder Ident has been activated.
-	IsOnGround bool `json:"-"`// = 21 //	 Flag to indicate ground squat switch is active
+	VerticalRate      int64  // = 16 //	 64ft resolution
+	Squawk            string // = 17 //	 Assigned Mode A squawk code.
+	AlertSquawkChange bool   `json:"-"` // = 18 // (Squawk change)	 Flag to indicate squawk has changed.
+	Emergency         bool   `json:"-"` // = 19 //	 Flag to indicate emergency code has been set
+	SPI               bool   `json:"-"` // = 20 // (Ident)	 Flag to indicate transponder Ident has been activated.
+	IsOnGround        bool   `json:"-"` // = 21 //	 Flag to indicate ground squat switch is active
 
 	// These fields are present for extended basestation format messages (i.e. MLAT)
 	NumStations int64 `json:"-"`
 	//ErrorEstimate int64 `json:"-"`  // Not sure if this is a float or an int, or what it means
-	
+
 	// Flags filled (and only valid) during initial SBS parsing, for fields not
 	// always present
 	hasAltitude     bool
@@ -66,25 +66,24 @@ type Msg struct {
 	hasVerticalRate bool
 }
 
-func (m Msg)IsMLAT() bool { return m.Type == "MLAT" }
+func (m Msg) IsMLAT() bool { return m.Type == "MLAT" }
 
-func (m Msg)IsMasked() bool { return strings.HasPrefix(string(m.Icao24), "~") }
+func (m Msg) IsMasked() bool { return strings.HasPrefix(string(m.Icao24), "~") }
 
 //func (m Msg)HasAltitude()     bool { return m.hasAltitude }
-func (m Msg)HasCallsign()     bool { return m.hasCallsign }
-func (m Msg)HasSquawk()       bool { return m.hasSquawk }
-func (m Msg)HasGroundSpeed()  bool { return m.hasGroundSpeed }
-func (m Msg)HasTrack()        bool { return m.hasTrack }
-func (m Msg)HasPosition()     bool { return m.hasPosition }
-func (m Msg)HasVerticalRate() bool { return m.hasVerticalRate }
+func (m Msg) HasCallsign() bool     { return m.hasCallsign }
+func (m Msg) HasSquawk() bool       { return m.hasSquawk }
+func (m Msg) HasGroundSpeed() bool  { return m.hasGroundSpeed }
+func (m Msg) HasTrack() bool        { return m.hasTrack }
+func (m Msg) HasPosition() bool     { return m.hasPosition }
+func (m Msg) HasVerticalRate() bool { return m.hasVerticalRate }
 
 // We create some ADSB messages outside of this lib, and need to assert these values
-func (m Msg)SetHasGroundSpeed() { m.hasGroundSpeed = true }
-func (m Msg)SetHasTrack()       { m.hasTrack = true }
-func (m Msg)SetHasPosition()    { m.hasPosition =true }
+func (m Msg) SetHasGroundSpeed() { m.hasGroundSpeed = true }
+func (m Msg) SetHasTrack()       { m.hasTrack = true }
+func (m Msg) SetHasPosition()    { m.hasPosition = true }
 
-
-func (m Msg)String() string {
+func (m Msg) String() string {
 	s := fmt.Sprintf("%s%d : %s", m.Type, m.SubType, m.Icao24)
 	if m.HasPosition() {
 		s += fmt.Sprintf(" %s", m.Position)

--- a/adsb_test.go
+++ b/adsb_test.go
@@ -1,0 +1,48 @@
+// go test -v github.com/skypies/adsb
+package adsb
+
+import (
+	"testing"
+)
+
+func TestAdsbMsgGroundSpeed(t *testing.T) {
+	m := Msg{}
+
+	if m.HasGroundSpeed() {
+		t.Errorf("ADS-B message should have no ground speed")
+	}
+
+	m.SetHasGroundSpeed()
+
+	if !m.HasGroundSpeed() {
+		t.Errorf("ADS-B message should have ground speed set")
+	}
+}
+
+func TestAdsbTrack(t *testing.T) {
+	m := Msg{}
+
+	if m.HasTrack() {
+		t.Errorf("ADS-B message should have no track")
+	}
+
+	m.SetHasTrack()
+
+	if !m.HasTrack() {
+		t.Errorf("ADS-B message should have track set")
+	}
+}
+
+func TestAdsbPosition(t *testing.T) {
+	m := Msg{}
+
+	if m.HasPosition() {
+		t.Errorf("ADS-B message should have no position")
+	}
+
+	m.SetHasPosition()
+
+	if !m.HasPosition() {
+		t.Errorf("ADS-B message should have position set")
+	}
+}

--- a/adsb_test.go
+++ b/adsb_test.go
@@ -46,3 +46,59 @@ func TestAdsbPosition(t *testing.T) {
 		t.Errorf("ADS-B message should have position set")
 	}
 }
+
+func TestAdsbAltitude(t *testing.T) {
+	m := Msg{}
+
+	if m.HasAltitude() {
+		t.Errorf("ADS-B message should have no altitude")
+	}
+
+	m.SetHasAltitude()
+
+	if !m.HasAltitude() {
+		t.Errorf("ADS-B message should have altitude set")
+	}
+}
+
+func TestAdsbCallsign(t *testing.T) {
+	m := Msg{}
+
+	if m.HasCallsign() {
+		t.Errorf("ADS-B message should have no callsign")
+	}
+
+	m.SetHasCallsign()
+
+	if !m.HasCallsign() {
+		t.Errorf("ADS-B message should have callsign set")
+	}
+}
+
+func TestAdsbVerticalRate(t *testing.T) {
+	m := Msg{}
+
+	if m.HasVerticalRate() {
+		t.Errorf("ADS-B message should have no vertical rate")
+	}
+
+	m.SetHasVerticalRate()
+
+	if !m.HasVerticalRate() {
+		t.Errorf("ADS-B message should have vertical rate")
+	}
+}
+
+func TestAdsbSquawk(t *testing.T) {
+	m := Msg{}
+
+	if m.HasSquawk() {
+		t.Errorf("ADS-B message should have no squawk")
+	}
+
+	m.SetHasSquawk()
+
+	if !m.HasSquawk() {
+		t.Errorf("ADS-B message should have squawk set")
+	}
+}

--- a/composite.go
+++ b/composite.go
@@ -14,19 +14,22 @@ import (
 type CompositeMsg struct {
 	Msg // Embedded stuct
 	// Real UTC timefields ??
-	ReceiverName  string // Some identifier for the ADS-B receiver that generated this data
+	ReceiverName string // Some identifier for the ADS-B receiver that generated this data
 }
 
 // Need to differentiate from 'real' ADSB messages, and synthetic MLAT messages
-func (cm CompositeMsg)DataSystem() string {
+func (cm CompositeMsg) DataSystem() string {
 	switch cm.Type {
-	case "MLAT": return "MLAT"
-	case "MSG": return "ADSB"
-	default: return cm.Type
+	case "MLAT":
+		return "MLAT"
+	case "MSG":
+		return "ADSB"
+	default:
+		return cm.Type
 	}
 }
 
-func (cm CompositeMsg)String() string {
+func (cm CompositeMsg) String() string {
 	pos := fmt.Sprintf(" (%.7f,%.7f)", cm.Position.Lat, cm.Position.Long)
 	return fmt.Sprintf("%s%d+ : %s[%7.7s] %5df, %3dk, %5df/m, %3ddeg, %s @ %s (%s) %s",
 		cm.Type, cm.SubType, cm.Icao24, cm.Callsign,
@@ -35,9 +38,10 @@ func (cm CompositeMsg)String() string {
 }
 
 type CompositeMsgPtrByTimeAsc []*CompositeMsg
-func (a CompositeMsgPtrByTimeAsc) Len() int          { return len(a) }
-func (a CompositeMsgPtrByTimeAsc) Swap(i,j int)      { a[i],a[j] = a[j],a[i] }
-func (a CompositeMsgPtrByTimeAsc) Less(i,j int) bool {
+
+func (a CompositeMsgPtrByTimeAsc) Len() int      { return len(a) }
+func (a CompositeMsgPtrByTimeAsc) Swap(i, j int) { a[i], a[j] = a[j], a[i] }
+func (a CompositeMsgPtrByTimeAsc) Less(i, j int) bool {
 	return a[j].GeneratedTimestampUTC.After(a[i].GeneratedTimestampUTC)
 }
 
@@ -51,8 +55,8 @@ func Base64EncodeMessages(msgs []*CompositeMsg) (string, error) {
 }
 
 func Base64DecodeMessages(str string) ([]*CompositeMsg, error) {
-	if data,err := base64.StdEncoding.DecodeString(str); err != nil {
-		return nil,err
+	if data, err := base64.StdEncoding.DecodeString(str); err != nil {
+		return nil, err
 	} else {
 		msgs := []*CompositeMsg{}
 		buf := bytes.NewBuffer(data)

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,7 @@ module github.com/skypies/adsb
 
 go 1.13
 
-require github.com/skypies/util v0.1.19 // indirect
+require (
+	github.com/skypies/geo v0.0.0-20180901233721-9d4f211f3066
+	github.com/skypies/util v0.1.19 // indirect
+)

--- a/msgbuffer/msgbuffer.go
+++ b/msgbuffer/msgbuffer.go
@@ -20,7 +20,7 @@ Sample usage:
     mb.FlushFunc = func(msgs []*adsb.CompositeMsg) {
       fmt.Printf("Just flushed %d messages\n", len(msgs))
     }
-    
+
     myMessages := []adsb.Message{ ... }
     for _,msg := range myMessages {
       mb.Add(msg}
@@ -29,10 +29,10 @@ Sample usage:
 */
 package msgbuffer
 
-import(
+import (
 	"fmt"
-	"time"
 	"github.com/skypies/adsb"
+	"time"
 )
 
 // {{{ ADSBSender{}
@@ -47,7 +47,7 @@ type ADSBSender struct {
 	LastSquawk        string
 }
 
-func (s ADSBSender)String() string {
+func (s ADSBSender) String() string {
 	return fmt.Sprintf("[%-7.7s],[%s] % 3dk, % 5df/m, % 3ddeg @ %s [%s]",
 		s.LastCallsign, s.LastSquawk, s.LastGroundSpeed, s.LastVerticalSpeed, s.LastTrack, s.LastSeen,
 		time.Since(s.LastSeen))
@@ -57,23 +57,27 @@ func (s ADSBSender)String() string {
 // {{{ MsgBuffer{}
 
 type MsgBuffer struct {
-	MinPublishInterval time.Duration  // Regardless of all else, don't publish faster than this
-	MaxMessageAge      time.Duration  // If we've held a message for more than this, flush the buffer
-	MaxQuietTime       time.Duration  // If a sender sends no messages for this long, remove it
+	MinPublishInterval time.Duration // Regardless of all else, don't publish faster than this
+	MaxMessageAge      time.Duration // If we've held a message for more than this, flush the buffer
+	MaxQuietTime       time.Duration // If a sender sends no messages for this long, remove it
 
-	Senders            map[adsb.IcaoId]*ADSBSender // Alive things we're currently getting data from
-	Messages        []*adsb.CompositeMsg           // The actual buffer of messages
+	Senders  map[adsb.IcaoId]*ADSBSender // Alive things we're currently getting data from
+	Messages []*adsb.CompositeMsg        // The actual buffer of messages
 
-	FlushChannel       chan<- []*adsb.CompositeMsg
-	lastFlush          time.Time
-	lastAgeOut         time.Time
+	FlushChannel chan<- []*adsb.CompositeMsg
+	lastFlush    time.Time
+	lastAgeOut   time.Time
 }
 
-func (mb MsgBuffer)String() string {
+func (mb MsgBuffer) String() string {
 	s := fmt.Sprintf("--{ MsgBuffer (maxage=%s, maxwait=%s, minpub=%s) }--\n",
 		mb.MaxMessageAge, mb.MaxQuietTime, mb.MinPublishInterval)
-	for k,sender := range mb.Senders { s += fmt.Sprintf(" - %s %s\n", k, sender) }
-	for i,m := range mb.Messages { s += fmt.Sprintf("[%02d] %s\n", i, m) }
+	for k, sender := range mb.Senders {
+		s += fmt.Sprintf(" - %s %s\n", k, sender)
+	}
+	for i, m := range mb.Messages {
+		s += fmt.Sprintf("[%02d] %s\n", i, m)
+	}
 	return s
 }
 
@@ -83,10 +87,10 @@ func (mb MsgBuffer)String() string {
 
 func NewMsgBuffer() *MsgBuffer {
 	return &MsgBuffer{
-		MinPublishInterval:  time.Second * 5,
-		MaxMessageAge:       time.Second * 30,
-		MaxQuietTime:        time.Second * 360,
-		Senders: make(map[adsb.IcaoId]*ADSBSender),
+		MinPublishInterval: time.Second * 5,
+		MaxMessageAge:      time.Second * 30,
+		MaxQuietTime:       time.Second * 360,
+		Senders:            make(map[adsb.IcaoId]*ADSBSender),
 	}
 }
 
@@ -97,22 +101,30 @@ func NewMsgBuffer() *MsgBuffer {
 // Some subtype packets have data we don't get in the bulk of position packets (those of subtype:3),
 // so just cache their interesting data and inject it into next position packet.
 // http://woodair.net/SBS/Article/Barebones42_Socket_Data.htm
-func (s *ADSBSender)updateFromMsg(m *adsb.Msg) {
+func (s *ADSBSender) updateFromMsg(m *adsb.Msg) {
 	s.LastSeen = time.Now().UTC()
 
 	// If the message had any of the optional fields, cache the value for later
-	if m.HasCallsign()      {
+	if m.HasCallsign() {
 		if len(m.Callsign) > 0 {
 			s.LastCallsign = m.Callsign
 		} else {
 			s.LastCallsign = "_._._._." // Our nil value :/
 		}
 	}
-	if m.HasSquawk()        { s.LastSquawk        = m.Squawk }
-	if m.HasGroundSpeed()   { s.LastGroundSpeed   = m.GroundSpeed }
-	if m.HasTrack()         { s.LastTrack         = m.Track }
-	if m.HasVerticalRate()  { s.LastVerticalSpeed = m.VerticalRate }
-	
+	if m.HasSquawk() {
+		s.LastSquawk = m.Squawk
+	}
+	if m.HasGroundSpeed() {
+		s.LastGroundSpeed = m.GroundSpeed
+	}
+	if m.HasTrack() {
+		s.LastTrack = m.Track
+	}
+	if m.HasVerticalRate() {
+		s.LastVerticalSpeed = m.VerticalRate
+	}
+
 	if m.Type == "MSG_foooo" {
 		if m.SubType == 1 {
 			// TODO: move this to m.hasCallsign()
@@ -120,20 +132,36 @@ func (s *ADSBSender)updateFromMsg(m *adsb.Msg) {
 			// don't really want to confuse flights that have a purposefully
 			// blank callsign with those for yet we've yet to receive a MSG,1.
 			// So we use a magic string instead.
-			if m.Callsign == ""     { s.LastCallsign      = "_._._._." }
-			if m.Callsign != ""     { s.LastCallsign      = m.Callsign }
-		
+			if m.Callsign == "" {
+				s.LastCallsign = "_._._._."
+			}
+			if m.Callsign != "" {
+				s.LastCallsign = m.Callsign
+			}
+
 		} else if m.SubType == 2 {
-			if m.HasGroundSpeed()   { s.LastGroundSpeed   = m.GroundSpeed }
-			if m.HasTrack()         { s.LastTrack         = m.Track }
+			if m.HasGroundSpeed() {
+				s.LastGroundSpeed = m.GroundSpeed
+			}
+			if m.HasTrack() {
+				s.LastTrack = m.Track
+			}
 
 		} else if m.SubType == 4 {
-			if m.HasGroundSpeed()   { s.LastGroundSpeed   = m.GroundSpeed }
-			if m.HasVerticalRate()  { s.LastVerticalSpeed = m.VerticalRate }
-			if m.HasTrack()         { s.LastTrack         = m.Track }
+			if m.HasGroundSpeed() {
+				s.LastGroundSpeed = m.GroundSpeed
+			}
+			if m.HasVerticalRate() {
+				s.LastVerticalSpeed = m.VerticalRate
+			}
+			if m.HasTrack() {
+				s.LastTrack = m.Track
+			}
 
 		} else if m.SubType == 6 {
-			if m.Squawk != ""       { s.LastSquawk        = m.Squawk }
+			if m.Squawk != "" {
+				s.LastSquawk = m.Squawk
+			}
 		}
 	}
 }
@@ -143,22 +171,32 @@ func (s *ADSBSender)updateFromMsg(m *adsb.Msg) {
 
 // If this message has new position info, *and* we have good backfill, then craft a CompositeMsg.
 // Note, we don't wait for squawk info.
-func (s *ADSBSender)maybeCreateComposite(m *adsb.Msg) *adsb.CompositeMsg {
+func (s *ADSBSender) maybeCreateComposite(m *adsb.Msg) *adsb.CompositeMsg {
 	if !m.HasPosition() {
 		return nil
 	}
 
 	//if s.LastGroundSpeed == 0 || s.LastTrack == 0 || s.LastCallsign == "" { return nil }
 
-	cm := adsb.CompositeMsg{Msg:*m}  // Clone the input into the embedded struct
+	cm := adsb.CompositeMsg{Msg: *m} // Clone the input into the embedded struct
 
 	// Overwrite with cached info (from previous packets), if we don't have it in this packet
-	if cm.GroundSpeed == 0  { cm.GroundSpeed  = s.LastGroundSpeed }
-	if cm.VerticalRate == 0 { cm.VerticalRate = s.LastVerticalSpeed }
-	if cm.Track == 0        { cm.Track        = s.LastTrack }
-	if cm.Callsign == ""    { cm.Callsign     = s.LastCallsign }
-	if cm.Squawk == ""      { cm.Squawk       = s.LastSquawk }
-	
+	if cm.GroundSpeed == 0 {
+		cm.GroundSpeed = s.LastGroundSpeed
+	}
+	if cm.VerticalRate == 0 {
+		cm.VerticalRate = s.LastVerticalSpeed
+	}
+	if cm.Track == 0 {
+		cm.Track = s.LastTrack
+	}
+	if cm.Callsign == "" {
+		cm.Callsign = s.LastCallsign
+	}
+	if cm.Squawk == "" {
+		cm.Squawk = s.LastSquawk
+	}
+
 	return &cm
 }
 
@@ -166,11 +204,13 @@ func (s *ADSBSender)maybeCreateComposite(m *adsb.Msg) *adsb.CompositeMsg {
 
 // {{{ MsgBuffer.ageOutQuietSenders
 
-func (mb *MsgBuffer)ageOutQuietSenders() (removed int64) {
-	if time.Since(mb.lastAgeOut) < time.Second { return } // Only run once per second.
+func (mb *MsgBuffer) ageOutQuietSenders() (removed int64) {
+	if time.Since(mb.lastAgeOut) < time.Second {
+		return
+	} // Only run once per second.
 	mb.lastAgeOut = time.Now()
 
-	for id,_ := range mb.Senders {
+	for id, _ := range mb.Senders {
 		if time.Since(mb.Senders[id].LastSeen) >= mb.MaxQuietTime {
 			delete(mb.Senders, id)
 			removed++
@@ -183,7 +223,7 @@ func (mb *MsgBuffer)ageOutQuietSenders() (removed int64) {
 // }}}
 // {{{ MsgBuffer.flush
 
-func (mb *MsgBuffer)flush() {
+func (mb *MsgBuffer) flush() {
 	if mb.FlushChannel != nil {
 		mb.FlushChannel <- mb.Messages
 	}
@@ -198,11 +238,11 @@ func (mb *MsgBuffer)flush() {
 // {{{ MsgBuffer.Add
 
 // MaybeAdd looks at a new message, and updates the buffer as appropriate.
-func (mb *MsgBuffer)Add(m *adsb.Msg) {
+func (mb *MsgBuffer) Add(m *adsb.Msg) {
 
 	mb.ageOutQuietSenders()
-	
-	if _,exists := mb.Senders[m.Icao24]; exists == false {
+
+	if _, exists := mb.Senders[m.Icao24]; exists == false {
 		// We've not seen this sender before. If we have position data,
 		// start the whitelisting thing. We only Whitelist senders who
 		// will eventually send useful info (e.g. position), so wait until
@@ -237,7 +277,7 @@ func (mb *MsgBuffer)Add(m *adsb.Msg) {
 // }}}
 // {{{ MsgBuffer.FinalFlush
 
-func (mb *MsgBuffer)FinalFlush() {
+func (mb *MsgBuffer) FinalFlush() {
 	mb.flush()
 }
 

--- a/sbs1.go
+++ b/sbs1.go
@@ -14,28 +14,28 @@ import (
 // http://woodair.net/SBS/Article/Barebones42_Socket_Data.htm
 // https://github.com/mutability/mlat-client/blob/master/mlat/client/output.py#L196
 const (
-	SBS1Message = 0 // type	 (MSG, STA, ID, AIR, SEL or CLK)
-	SBS1Transmission = 1 // Type	 MSG sub types 1 to 8. Not used by other message types.
-	SBS1Session = 2 // ID	 Database Session record number
-	SBS1AircraftID = 3 //	 Database Aircraft record number
-	SBS1Icao24 = 4 //	 Aircraft Mode S hexadecimal code
-	SBS1FlightID = 5 //	 Database Flight record number
-	SBS1DateGen = 6 // message generated	  As it says
-	SBS1TimeGen = 7 // message generated	  As it says
-	SBS1DateLog = 8 // message logged	  As it says
-	SBS1TimeLog = 9 // message logged	  As it says
-	SBS1Callsign = 10 //	 An eight digit flight ID - can be flight number or registration (or even nothing).
-	SBS1Altitude= 11 //	 Mode C altitude. Height relative to 1013.2mb (Flight Level). Not height AMSL..
-	SBS1GroundSpeed = 12 //	 Speed over ground (not indicated airspeed)
-	SBS1Track = 13 //	 Track of aircraft (not heading). Derived from the velocity E/W and velocity N/S
-	SBS1Latitude = 14 //	 North and East positive. South and West negative.
-	SBS1Longitude = 15 //	 North and East positive. South and West negative.
-	SBS1VerticalRate = 16 //	 64ft resolution
-	SBS1Squawk = 17 //	 Assigned Mode A squawk code.
+	SBS1Message           = 0  // type	 (MSG, STA, ID, AIR, SEL or CLK)
+	SBS1Transmission      = 1  // Type	 MSG sub types 1 to 8. Not used by other message types.
+	SBS1Session           = 2  // ID	 Database Session record number
+	SBS1AircraftID        = 3  // Database Aircraft record number
+	SBS1Icao24            = 4  // Aircraft Mode S hexadecimal code
+	SBS1FlightID          = 5  // Database Flight record number
+	SBS1DateGen           = 6  // message generated	  As it says
+	SBS1TimeGen           = 7  // message generated	  As it says
+	SBS1DateLog           = 8  // message logged	  As it says
+	SBS1TimeLog           = 9  // message logged	  As it says
+	SBS1Callsign          = 10 // An eight digit flight ID - can be flight number or registration (or even nothing).
+	SBS1Altitude          = 11 // Mode C altitude. Height relative to 1013.2mb (Flight Level). Not height AMSL..
+	SBS1GroundSpeed       = 12 // Speed over ground (not indicated airspeed)
+	SBS1Track             = 13 // Track of aircraft (not heading). Derived from the velocity E/W and velocity N/S
+	SBS1Latitude          = 14 // North and East positive. South and West negative.
+	SBS1Longitude         = 15 // North and East positive. South and West negative.
+	SBS1VerticalRate      = 16 // 64ft resolution
+	SBS1Squawk            = 17 // Assigned Mode A squawk code.
 	SBS1AlertSquawkChange = 18 // (Squawk change)	 Flag to indicate squawk has changed.
-	SBS1Emergency = 19 //	 Flag to indicate emergency code has been set
-	SBS1SPI = 20 // (Ident)	 Flag to indicate transponder Ident has been activated.
-	SBS1IsOnGround = 21 //	 Flag to indicate ground squat switch is active
+	SBS1Emergency         = 19 // Flag to indicate emergency code has been set
+	SBS1SPI               = 20 // (Ident)	 Flag to indicate transponder Ident has been activated.
+	SBS1IsOnGround        = 21 // Flag to indicate ground squat switch is active
 
 	// The extra fields for ext_basestation (used for MLAT output)
 	// https://github.com/mutability/mlat-client/blob/master/mlat/client/output.py#L264
@@ -45,11 +45,11 @@ const (
 )
 
 // Hack global. Maybe should have a parser struct.
-var TimeLocation = "UTC" // "America/Los_Angeles"  
+var TimeLocation = "UTC" // "America/Los_Angeles"
 
-func toTimeUTC(d,t string) (time.Time, error) {
+func toTimeUTC(d, t string) (time.Time, error) {
 	format := "2006/01/02 15:04:05.999999999"
-	value := d+" "+t
+	value := d + " " + t
 	if loc, err := time.LoadLocation(TimeLocation); err != nil {
 		panic(err)
 	} else if t, err := time.ParseInLocation(format, value, loc); err != nil {
@@ -59,10 +59,10 @@ func toTimeUTC(d,t string) (time.Time, error) {
 	}
 }
 
-func (m *Msg)FromSBS1(s string) error {
+func (m *Msg) FromSBS1(s string) error {
 	ioReader := strings.NewReader(s)
 	csvReader := csv.NewReader(ioReader)
-	if r,err := csvReader.Read(); err != nil {
+	if r, err := csvReader.Read(); err != nil {
 		return err
 	} else {
 
@@ -73,19 +73,19 @@ func (m *Msg)FromSBS1(s string) error {
 
 		// Dear god. If any block of code ever needed try/catch ...
 		m.Type = r[SBS1Message]
-		if i,err := strconv.ParseInt(r[SBS1Transmission], 10, 64); err != nil {
+		if i, err := strconv.ParseInt(r[SBS1Transmission], 10, 64); err != nil {
 			return err
 		} else {
 			m.SubType = i
 		}
 		m.Icao24 = IcaoId(r[SBS1Icao24])
-		
-		if t,err := toTimeUTC(r[SBS1DateGen], r[SBS1TimeGen]); err != nil {
+
+		if t, err := toTimeUTC(r[SBS1DateGen], r[SBS1TimeGen]); err != nil {
 			return err
-		} else {			
+		} else {
 			m.GeneratedTimestampUTC = t
 		}
-		if t,err := toTimeUTC(r[SBS1DateLog], r[SBS1TimeLog]); err != nil {
+		if t, err := toTimeUTC(r[SBS1DateLog], r[SBS1TimeLog]); err != nil {
 			return err
 		} else {
 			m.LoggedTimestampUTC = t
@@ -99,47 +99,47 @@ func (m *Msg)FromSBS1(s string) error {
 			m.hasSquawk = true
 			m.Squawk = strings.TrimSpace(r[SBS1Squawk])
 		}
-		
-		if (r[SBS1Altitude] != "") {
-			if i,err := strconv.ParseInt(r[SBS1Altitude], 10, 64); err != nil {
+
+		if r[SBS1Altitude] != "" {
+			if i, err := strconv.ParseInt(r[SBS1Altitude], 10, 64); err != nil {
 				return err
 			} else {
 				m.Altitude = i
 				m.hasAltitude = true
 			}
 		}
-		if (r[SBS1GroundSpeed] != "") {
-			if i,err := strconv.ParseInt(r[SBS1GroundSpeed], 10, 64); err != nil {
+		if r[SBS1GroundSpeed] != "" {
+			if i, err := strconv.ParseInt(r[SBS1GroundSpeed], 10, 64); err != nil {
 				return err
 			} else {
 				m.GroundSpeed = i
 				m.hasGroundSpeed = true
 			}
 		}
-		if (r[SBS1Track] != "") {
-			if i,err := strconv.ParseInt(r[SBS1Track], 10, 64); err != nil {
+		if r[SBS1Track] != "" {
+			if i, err := strconv.ParseInt(r[SBS1Track], 10, 64); err != nil {
 				return err
 			} else {
 				m.Track = i
 				m.hasTrack = true
 			}
 		}
-		if (r[SBS1VerticalRate] != "") {
-			if i,err := strconv.ParseInt(r[SBS1VerticalRate], 10, 64); err != nil {
+		if r[SBS1VerticalRate] != "" {
+			if i, err := strconv.ParseInt(r[SBS1VerticalRate], 10, 64); err != nil {
 				return err
 			} else {
 				m.VerticalRate = i
 				m.hasVerticalRate = true
 			}
 		}
-		
+
 		// Shoud prob decide this based on message type.
-		if (r[SBS1Latitude] != "" && r[SBS1Longitude] != "") {
-			if lat,err := strconv.ParseFloat(r[SBS1Latitude], 64); err != nil {
+		if r[SBS1Latitude] != "" && r[SBS1Longitude] != "" {
+			if lat, err := strconv.ParseFloat(r[SBS1Latitude], 64); err != nil {
 				return err
-			} else if long,err := strconv.ParseFloat(r[SBS1Longitude], 64); err != nil {
+			} else if long, err := strconv.ParseFloat(r[SBS1Longitude], 64); err != nil {
 				return err
-			} else {//if lat!=0.0 && long>0.0 { // Some dodgy data outputs nil locations as "0.00,0.00"
+			} else { //if lat!=0.0 && long>0.0 { // Some dodgy data outputs nil locations as "0.00,0.00"
 				m.Position = geo.Latlong{lat, long}
 				m.hasPosition = true
 			}
@@ -147,8 +147,8 @@ func (m *Msg)FromSBS1(s string) error {
 
 		// Extended basestation format ?
 		if len(r) == 25 {
-			if (r[ExtSBSNumStations] != "") {
-				if i,err := strconv.ParseInt(r[ExtSBSNumStations], 10, 64); err != nil {
+			if r[ExtSBSNumStations] != "" {
+				if i, err := strconv.ParseInt(r[ExtSBSNumStations], 10, 64); err != nil {
 					m.NumStations = i
 				}
 			}
@@ -163,37 +163,38 @@ func (m *Msg)FromSBS1(s string) error {
 	return nil
 }
 
-func (m *Msg)ToSBS1() string {
+func (m *Msg) ToSBS1() string {
 	r := make([]string, 22)
 
-	r[SBS1Message]      = m.Type
+	r[SBS1Message] = m.Type
 	r[SBS1Transmission] = fmt.Sprintf("%d", m.SubType)
 	//r[SBS1Session]      = "" // = 2 // ID	 Database Session record number
 	//r[SBS1AircraftID] = "" // = 3 //	 Database Aircraft record number
-	r[SBS1Icao24]       = string(m.Icao24)
+	r[SBS1Icao24] = string(m.Icao24)
 	//r[SBS1FlightID] = "" // = 5 //	 Database Flight record number
-	r[SBS1DateGen]      = m.GeneratedTimestampUTC.Format("2006/01/02")
-	r[SBS1TimeGen]      = m.GeneratedTimestampUTC.Format("15:04:05.999999999")
-	r[SBS1DateLog]      = m.LoggedTimestampUTC.Format("2006/01/02")
-	r[SBS1TimeLog]      = m.LoggedTimestampUTC.Format("15:04:05.999999999")
-	r[SBS1Callsign]     = m.Callsign
-	r[SBS1Altitude]     = fmt.Sprintf("%d", m.Altitude)
-	r[SBS1GroundSpeed]  = fmt.Sprintf("%d", m.GroundSpeed)
-	r[SBS1Track]        = fmt.Sprintf("%d", m.Track)
+	r[SBS1DateGen] = m.GeneratedTimestampUTC.Format("2006/01/02")
+	r[SBS1TimeGen] = m.GeneratedTimestampUTC.Format("15:04:05.999999999")
+	r[SBS1DateLog] = m.LoggedTimestampUTC.Format("2006/01/02")
+	r[SBS1TimeLog] = m.LoggedTimestampUTC.Format("15:04:05.999999999")
+	r[SBS1Callsign] = m.Callsign
+	r[SBS1Altitude] = fmt.Sprintf("%d", m.Altitude)
+	r[SBS1GroundSpeed] = fmt.Sprintf("%d", m.GroundSpeed)
+	r[SBS1Track] = fmt.Sprintf("%d", m.Track)
 
 	if m.HasPosition() {
-		r[SBS1Latitude]     = fmt.Sprintf("%.5f", m.Position.Lat)  // Too much precision ?
-		r[SBS1Longitude]    = fmt.Sprintf("%.5f", m.Position.Long)
+		r[SBS1Latitude] = fmt.Sprintf("%.5f", m.Position.Lat) // Too much precision ?
+		r[SBS1Longitude] = fmt.Sprintf("%.5f", m.Position.Long)
 	}
 	r[SBS1VerticalRate] = fmt.Sprintf("%d", m.VerticalRate)
-	r[SBS1Squawk]       = m.Squawk
+	r[SBS1Squawk] = m.Squawk
 	//r[SBS1AlertSquawkChange] = "" // = 18 // (Squawk change)	 Flag to indicate squawk has changed.
 	//r[SBS1Emergency] = "" // = 19 //	 Flag to indicate emergency code has been set
 	//r[SBS1SPI] = "" // = 20 // (Ident)	 Flag to indicate transponder Ident has been activated.
 	//r[SBS1IsOnGround] = "" // = 21 //	 Flag to indicate ground squat switch is active
 
 	// May need to do something here ...
-	if m.IsMLAT() {}
-	
+	if m.IsMLAT() {
+	}
+
 	return strings.Join(r, ",")
 }

--- a/sbs1_test.go
+++ b/sbs1_test.go
@@ -1,14 +1,14 @@
 // go test -v github.com/skypies/adsb
 package adsb
 
-import(
-	"fmt"
+import (
 	"bufio"
+	"fmt"
 	"strings"
 	"testing"
 )
 
-var(
+var (
 	sbs = `
 MSG,7,1,1,A81BD0,1,2015/11/27,21:31:02.722,2015/11/27,21:31:02.721,,20150,,,,,,,,,,0
 MSG,3,1,1,A81BD0,1,2015/11/27,21:31:03.354,2015/11/27,21:31:03.316,,20125,,,36.69804,-121.86007,,,,,,0
@@ -31,7 +31,9 @@ func TestSBSParsing(t *testing.T) {
 	scanner := bufio.NewScanner(strings.NewReader(sbs))
 	for scanner.Scan() {
 		text := scanner.Text()
-		if text == "" { continue } // blank lines
+		if text == "" {
+			continue
+		} // blank lines
 		m := Msg{}
 		fmt.Printf(" --- %s ---\n", text)
 		if err := m.FromSBS1(text); err != nil {
@@ -50,16 +52,18 @@ func TestExtendedSBSParsing(t *testing.T) {
 	scanner := bufio.NewScanner(strings.NewReader(extsbs))
 	for scanner.Scan() {
 		text := scanner.Text()
-		if text == "" { continue } // blank lines
+		if text == "" {
+			continue
+		} // blank lines
 		fmt.Printf(" --- %s ---\n", text)
 		m := Msg{}
 		if err := m.FromSBS1(text); err != nil {
 			t.Errorf("parse fail on '%s': %v", text, err)
 		}
-		if ! m.IsMLAT() {
+		if !m.IsMLAT() {
 			t.Errorf("extended parse not MLAT !")
 		}
-		if ! m.HasPosition() {
+		if !m.HasPosition() {
 			t.Errorf("extended parse has no position !\n%s\n%s", text, m.ToSBS1())
 		}
 	}
@@ -69,13 +73,15 @@ func TestMaskededSBSParsing(t *testing.T) {
 	scanner := bufio.NewScanner(strings.NewReader(maskedsbs))
 	for scanner.Scan() {
 		text := scanner.Text()
-		if text == "" { continue } // blank lines
+		if text == "" {
+			continue
+		} // blank lines
 		fmt.Printf(" --- %s ---\n", text)
 		m := Msg{}
 		if err := m.FromSBS1(text); err != nil {
 			t.Errorf("parse fail on '%s': %v", text, err)
 		}
-		if ! m.IsMasked() {
+		if !m.IsMasked() {
 			t.Errorf("not Masked !")
 		}
 	}

--- a/signature.go
+++ b/signature.go
@@ -8,13 +8,13 @@ import (
 // to identify the content of the message; if two messages have equivalent
 // Signatures, then we can consider them to be identical / duplicates.
 type Signature struct {
-	Pos geo.Latlong
+	Pos    geo.Latlong
 	Icao24 IcaoId
 }
 
-func (m *CompositeMsg)GetSignature() Signature {
+func (m *CompositeMsg) GetSignature() Signature {
 	return Signature{
-		Pos: m.Position,
+		Pos:    m.Position,
 		Icao24: m.Icao24,
 	}
 }

--- a/trackbuffer/trackbuffer.go
+++ b/trackbuffer/trackbuffer.go
@@ -3,62 +3,64 @@
 package trackbuffer
 
 import (
+	"github.com/skypies/adsb"
 	"sort"
 	"time"
-	"github.com/skypies/adsb"
 )
 
 // A slice of ADSB messages that share the same IcaoId
 type Track struct {
-	Messages  []*adsb.CompositeMsg
+	Messages []*adsb.CompositeMsg
 }
 
 type TrackBuffer struct {
-	MaxAge      time.Duration // Flush any track with data older than this
-	Tracks      map[adsb.IcaoId]*Track
-	lastFlush   time.Time
+	MaxAge    time.Duration // Flush any track with data older than this
+	Tracks    map[adsb.IcaoId]*Track
+	lastFlush time.Time
 }
 
 func NewTrackBuffer() *TrackBuffer {
 	tb := TrackBuffer{
-		MaxAge: time.Second*30,
-		Tracks: make(map[adsb.IcaoId]*Track),
+		MaxAge:    time.Second * 30,
+		Tracks:    make(map[adsb.IcaoId]*Track),
 		lastFlush: time.Now(),
 	}
 	return &tb
 }
 
-func (t *Track)Age() time.Duration {
-	if len(t.Messages)==0 { return time.Duration(time.Hour * 24) }
+func (t *Track) Age() time.Duration {
+	if len(t.Messages) == 0 {
+		return time.Duration(time.Hour * 24)
+	}
 	return time.Since(t.Messages[0].GeneratedTimestampUTC)
 }
 
-func (tb *TrackBuffer)AddTrack(icao adsb.IcaoId) {
+func (tb *TrackBuffer) AddTrack(icao adsb.IcaoId) {
 	track := Track{
 		Messages: []*adsb.CompositeMsg{},
 	}
 	tb.Tracks[icao] = &track
 }
 
-func (tb *TrackBuffer)RemoveTracks(icaos []adsb.IcaoId) []*Track{
+func (tb *TrackBuffer) RemoveTracks(icaos []adsb.IcaoId) []*Track {
 	removed := []*Track{}
-	for _,icao := range icaos {
+	for _, icao := range icaos {
 		removed = append(removed, tb.Tracks[icao])
 		delete(tb.Tracks, icao)
 	}
 	return removed
 }
 
-func (tb *TrackBuffer)Size() int64 {
+func (tb *TrackBuffer) Size() int64 {
 	i := 0
-	for _,t := range tb.Tracks {
+	for _, t := range tb.Tracks {
 		i += len(t.Messages)
 	}
 	return int64(i)
 }
 
-func (tb *TrackBuffer)AddMessage(m *adsb.CompositeMsg) {
-	if _,exists := tb.Tracks[m.Icao24]; exists == false {
+func (tb *TrackBuffer) AddMessage(m *adsb.CompositeMsg) {
+	if _, exists := tb.Tracks[m.Icao24]; exists == false {
 		tb.AddTrack(m.Icao24)
 	}
 	track := tb.Tracks[m.Icao24]
@@ -66,7 +68,7 @@ func (tb *TrackBuffer)AddMessage(m *adsb.CompositeMsg) {
 }
 
 // Flushing should be automatic and internal, not explicit like this.
-func (tb *TrackBuffer)Flush(flushChan chan<- []*adsb.CompositeMsg) {
+func (tb *TrackBuffer) Flush(flushChan chan<- []*adsb.CompositeMsg) {
 	// When we get late or out-of-order delivery, the timestamps in the messages will be so
 	// old that they will trigger immediate flushing every time. This causes so many DB writes
 	// that the system can't keep up, so we never get back to useful buffering. Put a mild rate
@@ -78,14 +80,14 @@ func (tb *TrackBuffer)Flush(flushChan chan<- []*adsb.CompositeMsg) {
 	}
 
 	toRemove := []adsb.IcaoId{}
-	
-	for id,_ := range tb.Tracks {
+
+	for id, _ := range tb.Tracks {
 		if tb.Tracks[id].Age() > tb.MaxAge {
 			toRemove = append(toRemove, id)
 		}
 	}
 
-	for _,t := range tb.RemoveTracks(toRemove) {
+	for _, t := range tb.RemoveTracks(toRemove) {
 		sort.Sort(adsb.CompositeMsgPtrByTimeAsc(t.Messages))
 		flushChan <- t.Messages
 	}


### PR DESCRIPTION
This PR includes several minor cleanups and fixes including the following bits:
- go fmt
- use pointer receivers for structure methods changing underlying structure
- add simple tests for ADS-B Msg structure